### PR TITLE
feat: require AWS_SESSION_TOKEN header for all requests

### DIFF
--- a/lib/extension/index.ts
+++ b/lib/extension/index.ts
@@ -1,24 +1,8 @@
-import Koa from 'koa'
-import Router from '@koa/router'
-
 import { next, register } from "./extensionsApi.js";
-import { getParameter, getParameters } from './ssm.js';
 import { logger } from './logging.js';
-import { variables } from './env.js';
+import { startServer } from "./server.js";
 
-const app = new Koa()
-const router = new Router()
-
-router.get('/systemsmanager/parameters/:parameterName', getParameter)
-router.get('/ssm/parameters/:parameterName', getParameter)
-router.get('/systemsmanager/parameters', getParameters)
-router.get('/ssm/parameters', getParameters)
-
-app
-  .use(router.routes())
-  .use(router.allowedMethods())
-app.listen(variables.HTTP_PORT)
-logger.info(`AWS Secrets Extension server is ready to receive requests on port ${variables.HTTP_PORT}`)
+startServer()
 
 const main = async () => {
   logger.debug('Registering extension')

--- a/lib/extension/server.ts
+++ b/lib/extension/server.ts
@@ -1,0 +1,40 @@
+import Koa from 'koa'
+import Router from '@koa/router'
+
+import { getParameter, getParameters } from './ssm.js';
+import { logger } from './logging.js';
+import { variables } from './env.js';
+
+const router = new Router()
+
+router.use(async(ctx, next) => {
+  const tokenHeader = ctx.headers['x-secrets-extension-token']
+
+  if (!tokenHeader) {
+    logger.error('Token header missing in request')
+    ctx.throw(401, JSON.stringify({ message: 'Missing auth header "X-Secrets-Extension-Token"' }))
+  }
+  
+  if (tokenHeader !== process.env.AWS_SESSION_TOKEN) {
+    logger.error('Token header does not have same value as AWS_SESSION_TOKEN')
+    ctx.throw(401, JSON.stringify({ message: 'Supplied auth header has incorrect value' }))
+  }
+
+  await next()
+})
+
+router.get('/systemsmanager/parameters/:parameterName', getParameter)
+router.get('/ssm/parameters/:parameterName', getParameter)
+router.get('/systemsmanager/parameters', getParameters)
+router.get('/ssm/parameters', getParameters)
+
+const app = new Koa()
+
+app
+  .use(router.routes())
+  .use(router.allowedMethods())
+
+export const startServer = () => {
+  app.listen(variables.HTTP_PORT)
+  logger.info(`AWS Secrets Extension server is ready to receive requests on port ${variables.HTTP_PORT}`)
+}


### PR DESCRIPTION
Fixes https://github.com/castodius/aws-secrets-extension/issues/5